### PR TITLE
Use Go 1.11 in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-  - '1.7'
+  - '1.11.x'
 before_install:
   - sudo add-apt-repository ppa:masterminds/glide -y
   - sudo apt-get update -q


### PR DESCRIPTION
Go 1.7 is toooooooooo old and dep cannot run with Go 1.7 ([ref](https://travis-ci.org/dtan4/ghrls/builds/474313106?utm_source=github_status&utm_medium=notification)).