### PR TITLE
Refactor get command implementation

### DIFF
--- a/github/github.go
+++ b/github/github.go
@@ -50,12 +50,12 @@ func NewClient(httpClient *http.Client) *Client {
 
 // DescribeRelease returns detail of the given release
 func (c *Client) DescribeRelease(owner, repo, tag string) (*Tag, error) {
-	release, err := c.GetRelease(owner, repo, tag)
+	release, err := c.getRelease(owner, repo, tag)
 	if err != nil {
 		return nil, err
 	}
 
-	commit, err := c.GetTagCommit(owner, repo, tag)
+	commit, err := c.getTagCommit(owner, repo, tag)
 	if err != nil {
 		return nil, err
 	}
@@ -116,8 +116,7 @@ func (c *Client) DescribeRelease(owner, repo, tag string) (*Tag, error) {
 	}, nil
 }
 
-// GetRelease returns release metadata of the given tag
-func (c *Client) GetRelease(owner, repo, tag string) (*github.RepositoryRelease, error) {
+func (c *Client) getRelease(owner, repo, tag string) (*github.RepositoryRelease, error) {
 	release, _, err := c.repositories.GetReleaseByTag(owner, repo, tag)
 	if err != nil {
 		return nil, err
@@ -126,8 +125,7 @@ func (c *Client) GetRelease(owner, repo, tag string) (*github.RepositoryRelease,
 	return release, nil
 }
 
-// GetTag returns commit metadata of the given tag
-func (c *Client) GetTagCommit(owner, repo, tag string) (*github.RepositoryCommit, error) {
+func (c *Client) getTagCommit(owner, repo, tag string) (*github.RepositoryCommit, error) {
 	commit, _, err := c.repositories.GetCommit(owner, repo, tag)
 	if err != nil {
 		return nil, err

--- a/github/github_test.go
+++ b/github/github_test.go
@@ -81,34 +81,6 @@ func (s fakeRepositoriesService) ListTags(owner string, repo string, opt *github
 	}, &github.Response{}, nil
 }
 
-func TestGetRelease(t *testing.T) {
-	c := &Client{
-		repositories: fakeRepositoriesService{},
-	}
-
-	owner := "owner"
-	repo := "repo"
-	tag := "tag"
-
-	if _, err := c.GetRelease(owner, repo, tag); err != nil {
-		t.Errorf("want no error, got %#v", err)
-	}
-}
-
-func TestGetTagCommit(t *testing.T) {
-	c := &Client{
-		repositories: fakeRepositoriesService{},
-	}
-
-	owner := "owner"
-	repo := "repo"
-	tag := "tag"
-
-	if _, err := c.GetTagCommit(owner, repo, tag); err != nil {
-		t.Errorf("want no error, got %#v", err)
-	}
-}
-
 func TestDescribeRelease(t *testing.T) {
 	c := &Client{
 		repositories: fakeRepositoriesService{},


### PR DESCRIPTION
- capsulate the logic to retrieve the details of Release into `github` package
- enrich test cases