### PR TITLE
Change github.NewClient argument to GitHub Access Token

### DIFF
--- a/cmd/get.go
+++ b/cmd/get.go
@@ -2,14 +2,12 @@ package cmd
 
 import (
 	"fmt"
-	"net/http"
 	"os"
 	"strings"
 	"text/tabwriter"
 
 	"github.com/dtan4/ghrls/github"
 	"github.com/spf13/cobra"
-	"golang.org/x/oauth2"
 )
 
 // getCmd represents the get command
@@ -52,18 +50,7 @@ func doGet(cmd *cobra.Command, args []string) error {
 
 	tag := args[1]
 
-	var httpClient *http.Client
-
-	if rootOpts.GitHubToken == "" {
-		httpClient = nil
-	} else {
-		ts := oauth2.StaticTokenSource(&oauth2.Token{
-			AccessToken: rootOpts.GitHubToken,
-		})
-		httpClient = oauth2.NewClient(oauth2.NoContext, ts)
-	}
-
-	client := github.NewClient(httpClient)
+	client := github.NewClient(rootOpts.GitHubToken)
 
 	t, err := client.DescribeRelease(owner, repo, tag)
 	if err != nil {

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -2,14 +2,12 @@ package cmd
 
 import (
 	"fmt"
-	"net/http"
 	"os"
 	"strings"
 	"text/tabwriter"
 
 	"github.com/dtan4/ghrls/github"
 	"github.com/spf13/cobra"
-	"golang.org/x/oauth2"
 )
 
 // listCmd represents the list command
@@ -55,18 +53,7 @@ func doList(cmd *cobra.Command, args []string) error {
 	}
 	owner, repo := ss[0], ss[1]
 
-	var httpClient *http.Client
-
-	if rootOpts.GitHubToken == "" {
-		httpClient = nil
-	} else {
-		ts := oauth2.StaticTokenSource(&oauth2.Token{
-			AccessToken: rootOpts.GitHubToken,
-		})
-		httpClient = oauth2.NewClient(oauth2.NoContext, ts)
-	}
-
-	client := github.NewClient(httpClient)
+	client := github.NewClient(rootOpts.GitHubToken)
 
 	tags, err := client.ListTagsAndReleases(owner, repo)
 	if err != nil {

--- a/github/github.go
+++ b/github/github.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/google/go-github/github"
+	"golang.org/x/oauth2"
 )
 
 const (
@@ -42,9 +43,20 @@ type Tag struct {
 }
 
 // NewClient creates new Client object
-func NewClient(httpClient *http.Client) *Client {
+func NewClient(accessToken string) *Client {
+	var hc *http.Client
+
+	if accessToken == "" {
+		hc = nil
+	} else {
+		ts := oauth2.StaticTokenSource(&oauth2.Token{
+			AccessToken: accessToken,
+		})
+		hc = oauth2.NewClient(oauth2.NoContext, ts)
+	}
+
 	return &Client{
-		repositories: github.NewClient(httpClient).Repositories,
+		repositories: github.NewClient(hc).Repositories,
 	}
 }
 

--- a/github/github_test.go
+++ b/github/github_test.go
@@ -81,6 +81,23 @@ func (s fakeRepositoriesService) ListTags(owner string, repo string, opt *github
 	}, &github.Response{}, nil
 }
 
+func TestNewClient(t *testing.T) {
+	testcases := []struct {
+		accessToken string
+	}{
+		{accessToken: ""},
+		{accessToken: "dummyaccesstoken"},
+	}
+
+	for _, tc := range testcases {
+		c := NewClient(tc.accessToken)
+
+		if c == nil {
+			t.Error("want: object, got: nil")
+		}
+	}
+}
+
 func TestDescribeRelease(t *testing.T) {
 	c := &Client{
 		repositories: fakeRepositoriesService{},


### PR DESCRIPTION
Users should not be aware of how to construct OAuth2 client.